### PR TITLE
Add data webpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store?
 thinking/
 *.bin
+*.elf
 .idea
 *.bak
 wifi-secure.json

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ cp boot.py /pyboard
 | `/reboot`      | Reboot system        | 							 |
 | `/select`      | Select WiFi network  | 							 |
 | `/setup`       | Setup system         | 							 |
+| `/info `       | System info          | 							 |
+| `/system_data` | Raw System info      | Latest system data as JSON |
 
 ### Available ModBus registers
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ cp boot.py /pyboard
 
 ## Usage
 
+### Available Webpages
+
+| URL            | Description          | Additional info |
+|----------------|----------------------|-----------------|
+| `/scan_result` | Latest Scan result   | Available networks as JSON |
+| `/configure`   | Manage WiFi networks |                            |
+| `/data`        | MyEVSE data          | Table of MyEVSE data       |
+| `/modbus_data` | Raw Modbus data      | Latest Modbus data as JSON |
+| `/reboot`      | Reboot system        | 							 |
+| `/select`      | Select WiFi network  | 							 |
+| `/setup`       | Setup system         | 							 |
+
 ### Available ModBus registers
 
 The available registers are defined by a JSON file and placed inside the

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/modbus_data` endpoint to make Modbus data available as JSON
 - `/system_data` endpoint to make system data available as JSON
 - Section with available webpages introduced in [`README`](README.md)
+- Custom logger is handed over to WiFi Manager run function to use `WARNING`
+  logging level compared to default `DEBUG` level for Picoweb
+
+### Changed
+- WiFi manager scan interval increased from 5 to 10 seconds
+- Modbus bridge and WiFi manager logger level increased from `DEBUG` to `INFO`
+- Neopixel changes from blue to green as soon as webinterface is running
 
 ## [0.1.0] - 2022-02-27
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
-## [0.2.0] - 2022-03-04
+## [0.2.0] - 2022-03-05
 ### Added
 - [`data.tpl`](templates/data.tpl) page to show latest Modbus data as table
+- [`info.tpl`](templates/info.tpl) page to show latest system data
 - `/modbus_data` endpoint to make Modbus data available as JSON
+- `/system_data` endpoint to make system data available as JSON
 - Section with available webpages introduced in [`README`](README.md)
 
 ## [0.1.0] - 2022-02-27

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.2.0] - 2022-03-04
+### Added
+- [`data.tpl`](templates/data.tpl) page to show latest Modbus data as table
+- `/modbus_data` endpoint to make Modbus data available as JSON
+- Section with available webpages introduced in [`README`](README.md)
+
 ## [0.1.0] - 2022-02-27
 ### Added
 - This changelog file
@@ -32,8 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.1.0...develop
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.2.0...main
 
+[0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
 [ref-pypi]: https://pypi.org/

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,2 +1,3 @@
-__version__ = '0.2.0'
+__version_info__ = ('0', '2', '0')
+__version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
                 'templates/reboot.tpl',
                 'templates/setup.tpl',
                 'templates/data.tpl',
+                'templates/system.tpl',
             ]
         )
     ],

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             [
                 'templates/reboot.tpl',
                 'templates/setup.tpl',
+                'templates/data.tpl',
             ]
         )
     ],

--- a/templates/data.tpl
+++ b/templates/data.tpl
@@ -21,17 +21,6 @@
     }@keyframes spin{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
   </style>
   <style type="text/css">
-    .list-group{width:auto;max-width:460px;margin:4rem auto}
-    .form-check-input:checked+.form-checked-content{opacity:.5}
-    .form-check-input-placeholder{pointer-events:none;border-style:dashed}[contenteditable]:focus{outline:0}
-    .list-group-checkable{display:grid;gap:.5rem;border:0}
-    .list-group-checkable .list-group-item{cursor:pointer;border-radius:.5rem}
-    .list-group-item-check{position:absolute;clip:rect(0,0,0,0);pointer-events:none}
-    .list-group-item-check:hover+.list-group-item{background-color:var(--bs-light)}
-    .list-group-item-check:checked+.list-group-item{color:#fff;background-color:var(--bs-blue)}
-    .list-group-item-check:disabled+.list-group-item,.list-group-item-check[disabled]+.list-group-item{pointer-events:none;filter:none;opacity:.5}
-  </style>
-  <style type="text/css">
     body {padding:50px 80px;}
   </style>
 </head>

--- a/templates/data.tpl
+++ b/templates/data.tpl
@@ -1,0 +1,111 @@
+{% args req, content %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
+  <meta name="description" content="Modbus Data">
+  <meta name="author" content="Jonas Scharpf aka brainelectronics">
+  <title>Modbus Data</title>
+  <link href="bootstrap.min.css" rel="stylesheet">
+  <!--
+  <link href="style.css" rel="stylesheet">
+  <link href="bootstrap.min.css" rel="stylesheet">
+  <link href="list-groups.css" rel="stylesheet">
+  -->
+  <style type="text/css">
+    .overlay{position:fixed;top:0;left:0;right:0;bottom:0;background-color:gray;color:#fff;opacity:1;transition:.5s;visibility:visible}
+    .overlay.hidden{opacity:0;visibility:hidden}
+    .loader{position:absolute;left:50%;top:50%;z-index:1;width:120px;height:120px;margin:-76px 0 0 -76px;border:16px solid #f3f3f3;border-radius:50%;border-top:16px solid #3498db;-webkit-animation:spin 2s linear infinite;animation:spin 2s linear infinite}
+    @-webkit-keyframes spin{0%{-webkit-transform:rotate(0)}100%{-webkit-transform:rotate(360deg)}
+    }@keyframes spin{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+  </style>
+  <style type="text/css">
+    .list-group{width:auto;max-width:460px;margin:4rem auto}
+    .form-check-input:checked+.form-checked-content{opacity:.5}
+    .form-check-input-placeholder{pointer-events:none;border-style:dashed}[contenteditable]:focus{outline:0}
+    .list-group-checkable{display:grid;gap:.5rem;border:0}
+    .list-group-checkable .list-group-item{cursor:pointer;border-radius:.5rem}
+    .list-group-item-check{position:absolute;clip:rect(0,0,0,0);pointer-events:none}
+    .list-group-item-check:hover+.list-group-item{background-color:var(--bs-light)}
+    .list-group-item-check:checked+.list-group-item{color:#fff;background-color:var(--bs-blue)}
+    .list-group-item-check:disabled+.list-group-item,.list-group-item-check[disabled]+.list-group-item{pointer-events:none;filter:none;opacity:.5}
+  </style>
+  <style type="text/css">
+    body {padding:50px 80px;}
+  </style>
+</head>
+<body>
+  <div id="overlay" class="overlay">
+    <div id="loader" class="loader"></div>
+  </div>
+
+  <div style="display:none;" id="myDiv" class="animate-bottom">
+    <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
+    <h4>Latest Modbus data</h4>
+    <div>
+      Data age:
+      <label id="data_age_minutes">00</label>:<label id="data_age_seconds">00</label> sec
+    </div>
+    <div name="modbus_data_table" id="modbus_data_table">
+      {{ content }}
+    </div>
+    <form>
+      <input type="button" class="btn btn-lg btn-warning list-group-item" onclick="window.location.href = '/';" value="Go Back"/>
+    </form>
+    </div>
+  </div>
+
+  <script>
+    var minutesLabel = document.getElementById("data_age_minutes");
+    var secondsLabel = document.getElementById("data_age_seconds");
+    var totalSeconds = 0;
+
+    window.onload = function(e) {
+      setTimeout(showPage, 1000);
+      setTimeout(get_new_data, 100);
+      var myInterval = setInterval(get_new_data, 10000);
+      setInterval(setDataAgeTime, 1000);
+    };
+    function showPage() {
+      document.getElementById("loader").style.display = "none";
+      document.getElementById("myDiv").style.display = "block";
+      //document.getElementById("rcorners3").style.display = "block";
+      document.getElementById("overlay").style.display = "none";
+    };
+    function setDataAgeTime() {
+      ++totalSeconds;
+      secondsLabel.innerHTML = pad(totalSeconds % 60);
+      minutesLabel.innerHTML = pad(parseInt(totalSeconds / 60));
+    }
+    function pad(val) {
+      var valString = val + "";
+      if (valString.length < 2) {
+        return "0" + valString;
+      } else {
+        return valString;
+      }
+    }
+    function get_new_data() {
+      // console.log('Getting new data');
+      var xmlhttp = new XMLHttpRequest();
+      var url = "modbus_data_table";
+      xmlhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+          var content = this.responseText;
+          // console.log(content);
+          document.getElementById("modbus_data_table").innerHTML = content;
+
+          if (selected_bssid) {
+            document.getElementById(selected_bssid).checked = true;
+          }
+        }
+      };
+      xmlhttp.open("GET", url);
+      xmlhttp.send();
+      // reset time of data age to zero
+      totalSeconds = 0;
+    }
+  </script>
+</body>
+</html>

--- a/templates/system.tpl
+++ b/templates/system.tpl
@@ -1,0 +1,78 @@
+{% args req, content %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
+  <meta name="description" content="System Info">
+  <meta name="author" content="Jonas Scharpf aka brainelectronics">
+  <title>System Info</title>
+  <link href="bootstrap.min.css" rel="stylesheet">
+  <!--
+  <link href="style.css" rel="stylesheet">
+  <link href="bootstrap.min.css" rel="stylesheet">
+  <link href="list-groups.css" rel="stylesheet">
+  -->
+  <style type="text/css">
+    .overlay{position:fixed;top:0;left:0;right:0;bottom:0;background-color:gray;color:#fff;opacity:1;transition:.5s;visibility:visible}
+    .overlay.hidden{opacity:0;visibility:hidden}
+    .loader{position:absolute;left:50%;top:50%;z-index:1;width:120px;height:120px;margin:-76px 0 0 -76px;border:16px solid #f3f3f3;border-radius:50%;border-top:16px solid #3498db;-webkit-animation:spin 2s linear infinite;animation:spin 2s linear infinite}
+    @-webkit-keyframes spin{0%{-webkit-transform:rotate(0)}100%{-webkit-transform:rotate(360deg)}
+    }@keyframes spin{0%{transform:rotate(0)}100%{transform:rotate(360deg)}}
+  </style>
+  <style type="text/css">
+    body {padding:50px 80px;}
+  </style>
+</head>
+<body>
+  <div id="overlay" class="overlay">
+    <div id="loader" class="loader"></div>
+  </div>
+
+  <div style="display:none;" id="myDiv" class="animate-bottom">
+    <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
+    <h4>Latest System Info</h4>
+    <div>
+      Data age:
+      <label id="data_age_minutes">00</label>:<label id="data_age_seconds">00</label> sec
+    </div>
+    <div name="system_info" id="system_info">
+      {{ content }}
+    </div>
+    <form>
+      <input type="button" class="btn btn-lg btn-warning list-group-item" onclick="window.location.href = '/';" value="Go Back"/>
+    </form>
+    </div>
+  </div>
+
+  <script>
+    var minutesLabel = document.getElementById("data_age_minutes");
+    var secondsLabel = document.getElementById("data_age_seconds");
+    var totalSeconds = 0;
+
+    window.onload = function(e) {
+      setTimeout(showPage, 1000);
+      setInterval(setDataAgeTime, 1000);
+    };
+    function showPage() {
+      document.getElementById("loader").style.display = "none";
+      document.getElementById("myDiv").style.display = "block";
+      //document.getElementById("rcorners3").style.display = "block";
+      document.getElementById("overlay").style.display = "none";
+    };
+    function setDataAgeTime() {
+      ++totalSeconds;
+      secondsLabel.innerHTML = pad(totalSeconds % 60);
+      minutesLabel.innerHTML = pad(parseInt(totalSeconds / 60));
+    }
+    function pad(val) {
+      var valString = val + "";
+      if (valString.length < 2) {
+        return "0" + valString;
+      } else {
+        return valString;
+      }
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Added
- [`data.tpl`](templates/data.tpl) page to show latest Modbus data as table
- [`info.tpl`](templates/info.tpl) page to show latest system data
- `/modbus_data` endpoint to make Modbus data available as JSON
- `/system_data` endpoint to make system data available as JSON
- Section with available webpages introduced in [`README`](README.md)
- Custom logger is handed over to WiFi Manager run function to use `WARNING` logging level compared to default `DEBUG` level for Picoweb

### Changed
- WiFi manager scan interval increased from 5 to 10 seconds
- Modbus bridge and WiFi manager logger level increased from `DEBUG` to `INFO`
- Neopixel changes from blue to green as soon as webinterface is running