### PR TITLE
Improve update and use new index pages style

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -9,6 +9,10 @@ Do initial stuff here, similar to the setup() function on Arduino
 
 # system packages
 import esp
+import machine
 
 # disable ESP os debug output
 esp.osdebug(None)
+
+# set clock speed to 240MHz instead of default 160MHz
+machine.freq(240000000)

--- a/changelog.md
+++ b/changelog.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - All `_tpl.py` inside `/lib/templates/` will be removed after an update to
   ensure the usage and display of the latest templates content
-- Available URLs dictionary has been updated to new WiFi Manager 1.3.0 style
-  and usage
+- Available URLs dictionary has been updated to new
+  [WiFi Manager 1.3.0][ref-wifi-manager-1.3.0] style and usage
 - Data webpage is no longer automatically updated every 10 seconds to reduce
   system load and to avoid `EOF on request start`, see [#4][ref-issue-4]
 - CPU clock speed increased from default 160MHz to 240MHz
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
+[ref-wifi-manager-1.3.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/releases/tag/1.3.0
 [ref-issue-4]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/4
 [ref-pypi]: https://pypi.org/
 [ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.4.0] - 2022-03-13
+### Changed
+- All `_tpl.py` inside `/lib/templates/` will be removed after an update to
+  ensure the usage and display of the latest templates content
+- Available URLs dictionary has been updated to new WiFi Manager 1.3.0 style
+  and usage
+- Data webpage is no longer automatically updated every 10 seconds to reduce
+  system load and to avoid `EOF on request start`, see [#4][ref-issue-4]
+- CPU clock speed increased from default 160MHz to 240MHz
+
+### Fixed
+- Register file path is set initially to correct path
+
 ## [0.3.0] - 2022-03-11
 ### Added
 - [`update.tpl`](templates/update.tpl) page to perform system update
@@ -59,11 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.3.0...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.4.0...main
 
+[0.4.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
+[ref-issue-4]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/4
 [ref-pypi]: https://pypi.org/
 [ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - All `_tpl.py` inside `/lib/templates/` will be removed after an update to
   ensure the usage and display of the latest templates content
+- All threads are stopped before a PyPi update
 - Available URLs dictionary has been updated to new
   [WiFi Manager 1.3.0][ref-wifi-manager-1.3.0] style and usage
 - Data webpage is no longer automatically updated every 10 seconds to reduce

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('0', '3', '0')
+__version_info__ = ('0', '4', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -865,8 +865,15 @@ class Webinterface(object):
 
         import upip
         upip.install('myevse-webinterface')
+        # 125.147ms, approx. 2 min
+
+        # remove already rendered template to ensure updated ones are shown
+        import os
+        templates_path = '/lib/templates/'
+        for ele in os.listdir(templates_path):
+            if ele.endswith('_tpl.py'):
+                os.remove(templates_path + ele)
 
         self.update_complete = True
-        # 125.147ms, approx. 2 min
 
         yield from picoweb.jsonify(resp, {'success': True})

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -887,6 +887,18 @@ class Webinterface(object):
             # But you can call it using yield from too.
             req.parse_qs()
 
+        # stop data collection and provisioning threads
+        self._mb_bridge.collecting_client_data = False
+        self._mb_bridge.provisioning_host_data = False
+
+        # stop WiFi scanning thread
+        self._wm.scanning = False
+
+        self._pixel.color = 'yellow'
+
+        # wait a bit to safely finish the may still running threads
+        time.sleep(5)
+
         gc.collect()
 
         self._update_ongoing = True

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -58,16 +58,16 @@ class Webinterface(object):
         self._restart_cause = 0
         self._connection_result = False
 
-        self._config_data = {
-            "TCP_PORT": 180,
-            "REGISTERS": "modbusRegisters-MyEVSE.json",
-            "CONNECTION_MODE": 0
-        }
         self._config_file_path = 'config.json'
         self._rtu_pins = (25, 26)     # (TX, RX)
         self._connection_mode = 0
         self._register_file = 'lib/registers/modbusRegisters-MyEVSE.json'
         self._tcp_port = 180
+        self._config_data = {
+            "TCP_PORT": self._tcp_port,
+            "REGISTERS": self._register_file,
+            "CONNECTION_MODE": self._connection_mode
+        }
 
         self._pixel.color = 'blue'
         self._pixel.intensity = 20

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -323,7 +323,7 @@ class Webinterface(object):
 
         try:
             # Modbus registers file path
-            self.register_file = 'lib/registers/' + cfg['REGISTERS']
+            self.register_file = cfg['REGISTERS']
         except Exception as e:
             self.logger.warning('Failed to set REGISTERS path: {}'.
                                 format(e))

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -390,13 +390,41 @@ class Webinterface(object):
 
         # add the new "Setup" and "Reboot" page to the index page
         self._wm.available_urls = {
-            "/setup": "Setup system",
-            "/reboot": "Reboot system",
-            "/data": "MyEVSE data",
-            "/modbus_data": "Raw Modbus data",
-            "/info": "System info",
-            "/system_data": "Raw system info",
-            "/update": "Update system",
+            "/setup": {
+                "title": "Setup system",
+                "color": "Configure Modbus TCP port, register file and WiFi connection mode",
+                "text": "text-white bg-success",
+            },
+            "/reboot": {
+                "title": "Reboot",
+                "color": "text-white bg-warning",
+                "text": "Reboot system",
+            },
+            "/data": {
+                "title": "MyEVSE data",
+                "color": "text-white bg-primary",
+                "text": "Show latest MyEVSE data as table",
+            },
+            "/modbus_data": {
+                "title": "Modbus data",
+                "color": "text-white bg-info",
+                "text": "Latest MyEVSE modbus data as JSON",
+            },
+            "/info": {
+                "title": "System info",
+                "color": "text-white bg-primary",
+                "text": "Show latest system data as table",
+            },
+            "/system_data": {
+                "title": "System data",
+                "color": "text-white bg-info",
+                "text": "Latest system data as JSON",
+            },
+            "/update": {
+                "title": "Update",
+                "color": "text-white bg-warning",
+                "text": "Update system",
+            },
         }
 
     def _save_system_config(self, data: dict) -> None:

--- a/templates/data.tpl
+++ b/templates/data.tpl
@@ -53,7 +53,7 @@
     window.onload = function(e) {
       setTimeout(showPage, 1000);
       setTimeout(get_new_data, 100);
-      var myInterval = setInterval(get_new_data, 10000);
+      // var myInterval = setInterval(get_new_data, 10000);
       setInterval(setDataAgeTime, 1000);
     };
     function showPage() {
@@ -87,6 +87,7 @@
         }
       };
       xmlhttp.open("GET", url);
+      // xmlhttp.timeout = 2000;   // leads to OSError: [Errno 104] ECONNRESET
       xmlhttp.send();
       // reset time of data age to zero
       totalSeconds = 0;


### PR DESCRIPTION
### Changed
- All `_tpl.py` inside `/lib/templates/` will be removed after an update to ensure the usage and display of the latest templates content
- Available URLs dictionary has been updated to new [WiFi Manager 1.3.0][ref-wifi-manager-1.3.0] style and usage
- Data webpage is no longer automatically updated every 10 seconds to reduce system load and to avoid `EOF on request start`, see [#4][ref-issue-4]
- CPU clock speed increased from default 160MHz to 240MHz

### Fixed
- Register file path is set initially to correct path

[ref-wifi-manager-1.3.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/releases/tag/1.3.0
[ref-issue-4]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/4
