### PR TITLE
Add used packages version info

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,54 @@
+# MyEVSE Webinterface
+
+[![Downloads](https://pepy.tech/badge/myevse-webinterface)](https://pepy.tech/project/myevse-webinterface)
+![Release](https://img.shields.io/github/v/release/brainelectronics/myevse-webinterface?include_prereleases&color=success)
+![MicroPython](https://img.shields.io/badge/micropython-Ok-green.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+MicroPython based Webinterface of MyEVSE
+
+---------------
+
+## Get started
+
+This is a quickstart guide o flash the
+[MicroPython firmware][ref-upy-firmware-download], connect to a network and
+install the MyEVSE Webinterface package on the board
+
+### Flash firmware
+
+```bash
+esptool.py --chip esp32 --port /dev/tty.SLAB_USBtoUART erase_flash
+esptool.py --chip esp32 --port /dev/tty.SLAB_USBtoUART --baud 921600 write_flash -z 0x1000 esp32spiram-20220117-v1.18.bin
+```
+
+### Install package on board with pip
+
+```python
+import machine
+import network
+import time
+import upip
+station = network.WLAN(network.STA_IF)
+station.active(True)
+station.connect('SSID', 'PASSWORD')
+time.sleep(1)
+print('Device connected to network: {}'.format(station.isconnected()))
+upip.install('myevse-webinterface')
+print('Installation completed')
+machine.soft_reset()
+```
+
+### Stop all threads
+
+```python
+# stop data collection and provisioning threads
+webinterface._mb_bridge.collecting_client_data = False
+webinterface._mb_bridge.provisioning_host_data = False
+
+# stop WiFi scanning thread
+webinterface._wm.scanning = False
+```
+
+<!-- Links -->
+[ref-upy-firmware-download]: https://micropython.org/download/

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.5.0] - 2022-03-20
+### Added
+- Versions of [WiFi Manager][ref-wifi-manager] and
+  [micropython be helpers][ref-micropython-modules] added to system info dict
+- [Quickstart](QUICKSTART.md) guide
+
+### Changed
+- Scanning thread is no longer started by webinterface.
+  [WiFi Manager 1.4.0][ref-wifi-manager-1.4.0] is starting the thread on the
+  property access
+
 ## [0.4.1] - 2022-03-13
 ### Fixed
 - System setup card text and color content were mixed up
@@ -77,14 +88,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.4.1...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.5.0...main
 
+[0.5.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.5.0
 [0.4.1]: https://github.com/brainelectronics/myevse-webinterface/tree/0.4.1
 [0.4.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
+[ref-wifi-manager]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager
+[ref-wifi-manager-1.4.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/releases/tag/1.4.0
+[ref-micropython-modules]: https://github.com/brainelectronics/micropython-modules
 [ref-wifi-manager-1.3.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/releases/tag/1.3.0
 [ref-issue-4]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/4
 [ref-pypi]: https://pypi.org/

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('0', '4', '1')
+__version_info__ = ('0', '5', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -21,10 +21,12 @@ import time
 # https://github.com/pfalcon/picoweb
 import picoweb
 # https://github.com/brainelectronics/micropython-modules
+from be_helpers import version as be_helpers_version
 from be_helpers.generic_helper import GenericHelper
 from be_helpers.led_helper import Led, Neopixel
 from be_helpers.modbus_bridge import ModbusBridge
 from be_helpers.path_helper import PathHelper
+from wifi_manager import version as wifi_manager_version
 from wifi_manager import WiFiManager
 from . import version as webinterface_version
 
@@ -655,6 +657,8 @@ class Webinterface(object):
         """
         sys_info = GenericHelper.get_system_infos_human()
         sys_info['version'] = webinterface_version.__version__
+        sys_info['version_be_helpers'] = be_helpers_version.__version__
+        sys_info['version_wifi_manager'] = wifi_manager_version.__version__
 
         return sys_info
 
@@ -849,7 +853,9 @@ class Webinterface(object):
             'total_ram': 'Total RAM',
             'percentage_ram': 'Percentage of free RAM',
             'frequency': 'System frequency',
-            'version': 'Software version',
+            'version': 'Software version Webinterface',
+            'version_be_helpers': 'Software version helpers',
+            'version_wifi_manager': 'Software version WiFiManager',
             'uptime': 'System uptime'
         }
 

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -596,9 +596,8 @@ class Webinterface(object):
         self._led.turn_off()
         self._pixel.color = 'green'
 
-        # start scanning for available networks
+        # set scanning interval, scan is started on property access
         self._wm.scan_interval = 10000
-        self._wm.scanning = True
 
         device_ip = self._mb_bridge._get_network_ip()
         self._wm.run(host=device_ip,


### PR DESCRIPTION
### Added
- Versions of [WiFi Manager][ref-wifi-manager] and [micropython be helpers][ref-micropython-modules] added to system info dict
- [Quickstart](QUICKSTART.md) guide

### Changed
- Scanning thread is no longer started by webinterface. [WiFi Manager 1.4.0][ref-wifi-manager-1.4.0] is starting the thread on the property access

[ref-wifi-manager]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager
[ref-wifi-manager-1.4.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/releases/tag/1.4.0
[ref-micropython-modules]: https://github.com/brainelectronics/micropython-modules