### PR TITLE
Hide specific pages

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,6 +24,20 @@ esptool.py --chip esp32 --port /dev/tty.SLAB_USBtoUART --baud 921600 write_flash
 
 ### Install package on board with pip
 
+```bash
+rshell -p /dev/tty.SLAB_USBtoUART --editor nano
+```
+
+Inside the rshell
+
+```bash
+cp main.py /pyboard
+cp boot.py /pyboard
+repl
+```
+
+Inside the REPL
+
 ```python
 import machine
 import network

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.6.0] - 2022-04-16
+### Changed
+- Modbus data pages are only available in client or access point mode, update
+  page only in client mode, see [#10][ref-issue-10]
+
+### Fixed
+- Added missing steps to copy [`boot.py`](boot.py) and [`main.py`](main.py)
+  files in [Quickstart](QUICKSTART.md) guide
+
 ## [0.5.0] - 2022-03-20
 ### Added
 - Versions of [WiFi Manager][ref-wifi-manager] and
@@ -88,8 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.5.0...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.6.0...main
 
+[0.6.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.6.0
 [0.5.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.5.0
 [0.4.1]: https://github.com/brainelectronics/myevse-webinterface/tree/0.4.1
 [0.4.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.4.0
@@ -97,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
+[ref-issue-10]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/10
 [ref-wifi-manager]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager
 [ref-wifi-manager-1.4.0]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager/releases/tag/1.4.0
 [ref-micropython-modules]: https://github.com/brainelectronics/micropython-modules

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('0', '5', '0')
+__version_info__ = ('0', '6', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -382,17 +382,8 @@ class Webinterface(object):
         self._wm.app.add_url_rule(url='/perform_reboot_system',
                                   func=self.perform_reboot_system)
 
-        self._wm.app.add_url_rule(url='/data', func=self.device_data)
-        self._wm.app.add_url_rule(url='/modbus_data', func=self.modbus_data)
-        self._wm.app.add_url_rule(url='/modbus_data_table',
-                                  func=self.modbus_data_table)
-
         self._wm.app.add_url_rule(url='/system_data', func=self.system_data)
         self._wm.app.add_url_rule(url='/info', func=self.system_info)
-
-        self._wm.app.add_url_rule(url='/update', func=self.update_system)
-        self._wm.app.add_url_rule(url='/perform_system_update',
-                                  func=self.perform_system_update)
 
         # add the new "Setup" and "Reboot" page to the index page
         self._wm.available_urls = {
@@ -406,16 +397,6 @@ class Webinterface(object):
                 "color": "text-white bg-warning",
                 "text": "Reboot system",
             },
-            "/data": {
-                "title": "MyEVSE data",
-                "color": "text-white bg-primary",
-                "text": "Show latest MyEVSE data as table",
-            },
-            "/modbus_data": {
-                "title": "Modbus data",
-                "color": "text-white bg-info",
-                "text": "Latest MyEVSE modbus data as JSON",
-            },
             "/info": {
                 "title": "System info",
                 "color": "text-white bg-primary",
@@ -426,12 +407,42 @@ class Webinterface(object):
                 "color": "text-white bg-info",
                 "text": "Latest system data as JSON",
             },
-            "/update": {
-                "title": "Update",
-                "color": "text-white bg-warning",
-                "text": "Update system",
-            },
         }
+
+        # add Modbus data pages only if device is setup as client or AP
+        if self.connection_mode in [self.CLIENT_MODE, self.ACCESSPOINT_MODE]:
+            self._wm.app.add_url_rule(url='/data', func=self.device_data)
+            self._wm.app.add_url_rule(url='/modbus_data',
+                                      func=self.modbus_data)
+            self._wm.app.add_url_rule(url='/modbus_data_table',
+                                      func=self.modbus_data_table)
+
+            self._wm.available_urls.update({
+                "/data": {
+                    "title": "MyEVSE data",
+                    "color": "text-white bg-primary",
+                    "text": "Show latest MyEVSE data as table",
+                },
+                "/modbus_data": {
+                    "title": "Modbus data",
+                    "color": "text-white bg-info",
+                    "text": "Latest MyEVSE modbus data as JSON",
+                },
+            })
+
+        # add update page only in client mode
+        if self.connection_mode in [self.CLIENT_MODE]:
+            self._wm.app.add_url_rule(url='/update', func=self.update_system)
+            self._wm.app.add_url_rule(url='/perform_system_update',
+                                      func=self.perform_system_update)
+
+            self._wm.available_urls.update({
+                "/update": {
+                    "title": "Update",
+                    "color": "text-white bg-warning",
+                    "text": "Update system",
+                },
+            })
 
     def _save_system_config(self, data: dict) -> None:
         """

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -38,6 +38,10 @@ class WebinterfaceError(Exception):
 
 class Webinterface(object):
     """docstring for Webinterface"""
+    SETUP_MODE = 0
+    CLIENT_MODE = 1
+    ACCESSPOINT_MODE = 2
+
     def __init__(self, logger=None, quiet=False, name=__name__):
         # setup and configure logger if none is provided
         if logger is None:
@@ -479,13 +483,13 @@ class Webinterface(object):
 
         connection_mode = self.connection_mode
 
-        if connection_mode == 0:
+        if connection_mode == self.SETUP_MODE:
             # device connection not yet configured
             self._wm.start_config()
-        elif connection_mode == 1:
+        elif connection_mode == self.CLIENT_MODE:
             # device connection configured
             connection_result = self._wm.load_and_connect()
-        elif connection_mode == 2:
+        elif connection_mode == self.ACCESSPOINT_MODE:
             # device configured as AccessPoint
             # abuse connection_result variable to create an AccessPoint later on
             connection_result = False
@@ -672,11 +676,11 @@ class Webinterface(object):
         client_checked = ""
         ap_checked = ""
 
-        if connection_mode == 0:
+        if connection_mode == self.SETUP_MODE:
             setup_checked = "checked"
-        elif connection_mode == 1:
+        elif connection_mode == self.CLIENT_MODE:
             client_checked = "checked"
-        elif connection_mode == 2:
+        elif connection_mode == self.ACCESSPOINT_MODE:
             ap_checked = "checked"
 
         yield from picoweb.start_response(resp)


### PR DESCRIPTION
### Changed
- Modbus data pages are only available in client or access point mode, update page only in client mode, see #10 

### Fixed
- Added missing steps to copy [`boot.py`](boot.py) and [`main.py`](main.py) files in [Quickstart](QUICKSTART.md) guide