### PR TITLE
Perform webinterface update calls in background

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,15 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.8.0] - 2022-04-18
+### Changed
+- `/setup` and `/reboot` pages show success banner after posting new config
+  data and triggering a reboot . `/setup` does not redirect anymore after
+  submitting the config. The reboot of the system is done after the response
+  has been sent to from the system. A circular progressbar is shown as long as
+  the reboot progress is active and redirects to the index page after 45 sec
+  which should be enough to fully reboot the system, see [#16][ref-issue-16]
+
 ## [0.7.0] - 2022-04-17
 ### Changed
 - AccessPoint of MyEVSE is named `MyEVSE_xxxx` with `xxxx` as the first four
@@ -106,8 +115,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.7.0...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.8.0...main
 
+[0.8.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.7.0
 [0.6.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.6.0
 [0.5.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.5.0
@@ -117,6 +127,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 [0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
+[ref-issue-16]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/16
 [ref-issue-14]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/14
 [ref-issue-10]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/10
 [ref-wifi-manager]: https://github.com/brainelectronics/Micropython-ESP-WiFi-Manager

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('0', '7', '0')
+__version_info__ = ('0', '8', '0')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -727,10 +727,11 @@ class Webinterface(object):
             # But you can call it using yield from too.
             req.parse_qs()
 
+        # empty response to avoid any redirects or errors due to none response
+        yield from picoweb.start_response(resp, status='204')
+
         # perform soft reset, like CTRL+D
         machine.soft_reset()
-
-        yield from picoweb.jsonify(resp, {'success': True})
 
     # @app.route("/save_system_config")
     def save_system_config(self, req, resp) -> None:
@@ -756,9 +757,8 @@ class Webinterface(object):
 
         self._save_system_config(data=form_data)
 
-        # redirect to '/'
-        headers = {'Location': '/'}
-        yield from picoweb.start_response(resp, status='303', headers=headers)
+        # empty response to avoid any redirects or errors due to none response
+        yield from picoweb.start_response(resp, status='204')
 
     def _render_modbus_data(self, device_data: dict) -> str:
         """

--- a/templates/reboot.tpl
+++ b/templates/reboot.tpl
@@ -7,6 +7,7 @@
   <meta name="author" content="Jonas Scharpf aka brainelectronics">
   <title>Reboot system</title>
   <link href="bootstrap.min.css" rel="stylesheet">
+  <script type="text/javascript" src="toast.js"></script>
   <style type="text/css">
     .overlay{position:fixed;top:0;left:0;right:0;bottom:0;background-color:gray;color:#fff;opacity:1;transition:.5s;visibility:visible}
     .overlay.hidden{opacity:0;visibility:hidden}
@@ -32,6 +33,7 @@
 <body>
   <div id="overlay" class="overlay">
     <div id="loader" class="loader"></div>
+    <canvas id="circularLoader" width="200" height="200" style="position:absolute;left:50%;top:50%;z-index:1;width:120px;height:120px;margin:-76px 0 0 -76px;"></canvas>
   </div>
 
   <div style="display:none;" id="myDiv" class="animate-bottom">
@@ -47,6 +49,7 @@
       </form>
     </div>
   </div>
+  <div id="alert_container" style="position: fixed;z-index: 9999;top: 20px;right: 20px;"></div>
 
   <script>
     window.onload = function(e) {
@@ -55,13 +58,49 @@
     function showPage() {
       document.getElementById("loader").style.display = "none";
       document.getElementById("myDiv").style.display = "block";
-      //document.getElementById("rcorners3").style.display = "block";
       document.getElementById("overlay").style.display = "none";
     };
     document.getElementById("perform_reboot_system_form").onsubmit = function(e) {
-      window.onbeforeunload = null;
-      return confirm("Are you sure you want to reboot?");
+      var res = confirm("Rebooting the system?");
+      if (res) {
+        var xmlhttp = new XMLHttpRequest();
+        var url = '/perform_reboot_system';
+        xmlhttp.open('POST', url, true);
+        var data = JSON.stringify({"reboot": true});
+        xmlhttp.send(data);
+        createToast('alert-success', 'Success!', 'System is rebooting...', 45000);
+        startProgress(1, 450);
+      }
+      return res;
     };
+    var ctx = document.getElementById('circularLoader').getContext('2d');
+    var diff,sim,val=0,start=4.72,cw=ctx.canvas.width,ch=ctx.canvas.height;
+    function progressCircle(inc) {
+      val += inc;
+      if(val < 0){val = 0};
+      if(val > 100){val = 100};
+      diff = ((val / 100) * Math.PI*2*10).toFixed(2);
+      ctx.clearRect(0, 0, cw, ch);
+      ctx.lineWidth = 17;
+      ctx.fillStyle = '#f3f3f3';
+      ctx.strokeStyle = '#f3f3f3';
+      ctx.textAlign = "center";
+      ctx.font = "28px monospace";
+      ctx.fillText(val+'%', cw*.52, ch*.5+5, cw+12);
+      ctx.beginPath();
+      ctx.arc(100, 100, 75, start, diff/10+start, false);
+      ctx.stroke();
+      if(val >= 100){
+        clearTimeout(sim);
+        window.location='/';
+      }
+    }
+    function startProgress(inc, t){
+      document.getElementById("overlay").style.display = "block";
+      document.getElementById("myDiv").style.display = "none";
+      progressCircle(inc);
+      sim = setInterval(function() {progressCircle(inc)}, t);
+    }
   </script>
 </body>
 </html>

--- a/templates/setup.tpl
+++ b/templates/setup.tpl
@@ -8,6 +8,7 @@
   <meta name="author" content="Jonas Scharpf aka brainelectronics">
   <title>Setup system</title>
   <link href="bootstrap.min.css" rel="stylesheet">
+  <script type="text/javascript" src="toast.js"></script>
   <style type="text/css">
     .overlay{position:fixed;top:0;left:0;right:0;bottom:0;background-color:gray;color:#fff;opacity:1;transition:.5s;visibility:visible}
     .overlay.hidden{opacity:0;visibility:hidden}
@@ -87,6 +88,7 @@
     </div>
     </div>
   </div>
+  <div id="alert_container" style="position: fixed;z-index: 9999;top: 20px;right: 20px;"></div>
 
   <script>
     window.onload = function(e) {
@@ -95,11 +97,10 @@
     function showPage() {
       document.getElementById("loader").style.display = "none";
       document.getElementById("myDiv").style.display = "block";
-      //document.getElementById("rcorners3").style.display = "block";
       document.getElementById("overlay").style.display = "none";
     };
     document.getElementById("save_system_config_form").onsubmit = function(e) {
-      window.onbeforeunload = null;
+      createToast('alert-success', 'Success!', 'Configuration updated', 5000);
       return true;
     };
   </script>


### PR DESCRIPTION
### Changed
- `/setup` and `/reboot` pages show success banner after posting new config data and triggering a reboot . `/setup` does not redirect anymore after submitting the config. The reboot of the system is done after the response has been sent to from the system. A circular progressbar is shown as long as the reboot progress is active and redirects to the index page after 45 sec which should be enough to fully reboot the system, see #16 