### PR TITLE
Increase reboot spinner time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,15 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.8.1] - 2022-04-20
+### Changed
+- Form post of `/setup` changed to vanilla JavaScript JSON post
+
+### Fixed
+- Increase spinner time at `/reboot` from 45 to 60 seconds to ensure a full
+  reboot of the device, see [#16][ref-issue-16]
+- Prevent redirection to POST URL on `/reboot` and `/setup` pages
+
 ## [0.8.0] - 2022-04-18
 ### Changed
 - `/setup` and `/reboot` pages show success banner after posting new config
@@ -115,8 +124,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.8.0...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.8.1...main
 
+[0.8.1]: https://github.com/brainelectronics/myevse-webinterface/tree/0.8.1
 [0.8.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.7.0
 [0.6.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.6.0
@@ -127,6 +137,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 [0.2.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.2.0
 [0.1.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.1.0
 
+[ref-issue-17]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/17
 [ref-issue-16]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/16
 [ref-issue-14]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/14
 [ref-issue-10]: https://github.com/brainelectronics/MyEVSE-Webinterface/issues/10

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('0', '8', '0')
+__version_info__ = ('0', '8', '1')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -736,14 +736,18 @@ class Webinterface(object):
     # @app.route("/save_system_config")
     def save_system_config(self, req, resp) -> None:
         """Process saving the specified system configs"""
+        """
         if req.method == 'POST':
             yield from req.read_form_data()
         else:  # GET, apparently
             # Note: parse_qs() is not a coroutine, but a normal function.
             # But you can call it using yield from too.
             req.parse_qs()
-
-        form_data = req.form
+        """
+        size = int(req.headers[b"Content-Length"])
+        data = yield from req.reader.readexactly(size)
+        decoded_data = data.decode()
+        form_data = GenericHelper.str_to_dict(data=decoded_data)
 
         # Whether form data comes from GET or POST request, once parsed,
         # it's available as req.form dictionary

--- a/templates/reboot.tpl
+++ b/templates/reboot.tpl
@@ -69,7 +69,7 @@
         var data = JSON.stringify({"reboot": true});
         xmlhttp.send(data);
         createToast('alert-success', 'Success!', 'System is rebooting...', 45000);
-        startProgress(1, 450);
+        startProgress(1, 600);
       }
       return res;
     };

--- a/templates/reboot.tpl
+++ b/templates/reboot.tpl
@@ -63,6 +63,9 @@
     document.getElementById("perform_reboot_system_form").onsubmit = function(e) {
       var res = confirm("Rebooting the system?");
       if (res) {
+        // do not redirect somewhere
+        e.preventDefault();
+        window.onbeforeunload = null;
         var xmlhttp = new XMLHttpRequest();
         var url = '/perform_reboot_system';
         xmlhttp.open('POST', url, true);

--- a/templates/setup.tpl
+++ b/templates/setup.tpl
@@ -100,6 +100,16 @@
       document.getElementById("overlay").style.display = "none";
     };
     document.getElementById("save_system_config_form").onsubmit = function(e) {
+      // do not redirect somewhere
+      e.preventDefault();
+      window.onbeforeunload = null;
+      var xmlhttp = new XMLHttpRequest();
+      var url = '/save_system_config';
+      xmlhttp.open('POST', url, true);
+      var formData = new FormData(document.getElementById("save_system_config_form"));
+      xmlhttp.setRequestHeader("Content-Type", "application/json");
+      var data = JSON.stringify(Object.fromEntries(formData));
+      xmlhttp.send(data);
       createToast('alert-success', 'Success!', 'Configuration updated', 5000);
       return true;
     };


### PR DESCRIPTION
### Changed
- Form post of `/setup` changed to vanilla JavaScript JSON post

### Fixed
- Increase spinner time at `/reboot` from 45 to 60 seconds to ensure a full reboot of the device, see #16 
- Prevent redirection to POST URL on `/reboot` and `/setup` pages
