### PR TITLE
Fix unique accesspoint name again

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,11 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.8.2] - 2022-05-06
+### Fixed
+- Use last 4 characters of UUID as unique AccessPoint name, see additional
+  comment in [#14][ref-issue-14]
+
 ## [0.8.1] - 2022-04-20
 ### Changed
 - Form post of `/setup` changed to vanilla JavaScript JSON post
@@ -124,8 +129,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.8.1...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.8.2...main
 
+[0.8.2]: https://github.com/brainelectronics/myevse-webinterface/tree/0.8.2
 [0.8.1]: https://github.com/brainelectronics/myevse-webinterface/tree/0.8.1
 [0.8.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.7.0

--- a/myevse_webinterface/version.py
+++ b/myevse_webinterface/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ('0', '8', '1')
+__version_info__ = ('0', '8', '2')
 __version__ = '.'.join(__version_info__)
 __author__ = 'brainelectronics'

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -525,7 +525,7 @@ class Webinterface(object):
 
             # create a true AccessPoint without any active Station mode
             ap_name = 'MyEVSE_{}'.format(
-                GenericHelper.get_uuid(4).decode('ascii'))
+                GenericHelper.get_uuid(-4).decode('ascii'))
             self.logger.info('Starting MyEVSE in AccessPoint mode named "{}"'.
                              format(ap_name))
             self._wm.wh.create_ap(ssid=ap_name,


### PR DESCRIPTION
### Fixed
- Use last 4 characters of UUID as unique AccessPoint name, see additional comment in [#14][ref-issue-14]
