### PR TITLE
Use async microdot

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,13 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 <!-- ## [Unreleased] -->
 
 ## Released
+## [0.11.0] - 2023-02-18
+### Changed
+- Webserver functions use `async` and `await` to become asynchronous
+
+### Removed
+- `wait_for_irq` returns instantly, no longer required due to `/shutdown` enpoint introduced in Micropython ESP WiFi Manager 1.10.0
+
 ## [0.10.0] - 2023-02-17
 ### Added
 - Custom PyPi server is used for package test version installation
@@ -174,8 +181,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
   [pfalcon's picoweb repo][ref-pfalcon-picoweb-sdist-upip] and PEP8 improved
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.10.0...main
+[Unreleased]: https://github.com/brainelectronics/myevse-webinterface/compare/0.11.0...main
 
+[0.11.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.11.0
 [0.10.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.10.0
 [0.9.1]: https://github.com/brainelectronics/myevse-webinterface/tree/0.9.1
 [0.9.0]: https://github.com/brainelectronics/myevse-webinterface/tree/0.9.0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -32,6 +32,7 @@ Further examples are available in the [examples chapter](EXAMPLES.md)
 | `/modbus_data` | Raw Modbus data      | Latest Modbus data as JSON |
 | `/reboot`      | Reboot system        |                            |
 | `/system_data` | Raw System info      | Latest system data as JSON |
+| `/shutdown`    | Shutdown webserver   | Return from `run` function |
 
 ### Available ModBus registers
 

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -638,36 +638,11 @@ class Webinterface(object):
         Modbus data collection and provision are stopped. Any active WiFi
         scanning thread is stopped as well.
         """
-        start_time = time.time()
-        while True:
-            try:
-                machine.idle()
-            except KeyboardInterrupt:
-                self.logger.debug('KeyboardInterrupt, stop MB threads {}'.
-                                  format(time.time() - start_time))
-                self._pixel.clear()
-                break
-            except Exception as e:
-                self.logger.info('Exception during wait_for_irq: {}'.
-                                 format(e))
-                self._pixel.clear()
-
-        # stop data collection and provisioning threads
-        self._mb_bridge.collecting_client_data = False
-        self._mb_bridge.provisioning_host_data = False
-
-        # stop WiFi scanning thread
-        self._wm.scanning = False
-
-        # wait a bit to safely finish the may still running threads
-        time.sleep(5)
-
-        # finally turn of Neopixel and LED
-        self._pixel.clear()
-        self._led.turn_off()
-
-        app_runtime = time.ticks_diff(time.ticks_ms(), self._boot_time_ticks)
-        self.logger.debug('Application run time: {}ms'.format(app_runtime))
+        pass
+        # new endpoint '/shutdown' has been introduced with Micropython ESP
+        # WiFi Manager 1.10.0
+        # This function has to be available as the main.py file is not updated
+        # with any updates and is calling this function at some point in time
 
     @property
     def system_infos(self) -> dict:

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -19,7 +19,7 @@ import time
 # custom modules
 # pip installed packages
 # https://github.com/miguelgrinberg/microdot
-from microdot import Request, Response, send_file
+from microdot.microdot_asyncio import Request, Response, send_file
 from microdot.microdot_utemplate import render_template, init_templates
 
 # https://github.com/brainelectronics/micropython-modules
@@ -688,7 +688,7 @@ class Webinterface(object):
     # Webserver functions
 
     # @app.route('/setup')
-    def system_config(self, req: Request) -> None:
+    async def system_config(self, req: Request) -> None:
         connection_mode = self.connection_mode
 
         setup_checked = ""
@@ -711,7 +711,7 @@ class Webinterface(object):
                                ap_checked=ap_checked)
 
     # @app.route('/reboot_system')
-    def reboot_system(self, req: Request) -> None:
+    async def reboot_system(self, req: Request) -> None:
         """Reboot the system"""
         res = send_file('/lib/templates/reboot.tpl')
         res.headers["Content-Type"] = "text/html"
@@ -719,7 +719,7 @@ class Webinterface(object):
         return res
 
     # @app.route('/perform_reboot_system')
-    def perform_reboot_system(self, req: Request) -> None:
+    async def perform_reboot_system(self, req: Request) -> None:
         """Process system reboot"""
         # perform soft reset, like CTRL+D
         machine.soft_reset()
@@ -727,7 +727,7 @@ class Webinterface(object):
         return None, 204, {'Content-Type': 'application/json; charset=UTF-8'}
 
     # @app.route('/save_system_config')
-    def save_system_config(self, req: Request) -> None:
+    async def save_system_config(self, req: Request) -> None:
         """Process saving the specified system configs"""
         form_data = req.json
 
@@ -741,7 +741,7 @@ class Webinterface(object):
         #     'REGISTERS': 'modbusRegisters-MyEVSE.json'
         # }
 
-        self._save_system_config(data=form_data)
+        await self._save_system_config(data=form_data)
 
         # empty response to avoid any redirects or errors due to none response
         return None, 204, {'Content-Type': 'application/json; charset=UTF-8'}
@@ -815,29 +815,29 @@ class Webinterface(object):
         return content
 
     # @app.route('/data')
-    def device_data(self, req: Request) -> None:
+    async def device_data(self, req: Request) -> None:
         """Provide webpage listing the latest device data as table"""
         latest_data = self._mb_bridge.client_data
-        content = self._render_modbus_data(device_data=latest_data)
+        content = await self._render_modbus_data(device_data=latest_data)
 
         return render_template(template='data.tpl', req=None, content=content)
 
     # @app.route('/modbus_data')
-    def modbus_data(self, req: Request) -> None:
+    async def modbus_data(self, req: Request) -> None:
         """Provide latest modbus data as JSON"""
         # https://microdot.readthedocs.io/en/latest/intro.html#json-responses
         return self._mb_bridge.client_data
 
     # @app.route('/modbus_data_table')
-    def modbus_data_table(self, req: Request) -> None:
+    async def modbus_data_table(self, req: Request) -> None:
         """Provide latest modbus data table HTML code"""
         latest_data = self._mb_bridge.client_data
-        content = self._render_modbus_data(device_data=latest_data)
+        content = await self._render_modbus_data(device_data=latest_data)
 
         return content
 
     # @app.route('/info')
-    def system_info(self, req: Request) -> None:
+    async def system_info(self, req: Request) -> None:
         """Provide webpage listing the latest device data"""
         latest_data = self.system_infos
 
@@ -855,18 +855,18 @@ class Webinterface(object):
             'uptime': 'System uptime'
         }
 
-        content = self._render_system_info(system_data=latest_data)
+        content = await self._render_system_info(system_data=latest_data)
 
         return render_template(template='system.tpl', req=0, content=content)
 
     # @app.route('/system_data')
-    def system_data(self, req: Request) -> None:
+    async def system_data(self, req: Request) -> None:
         """Provide latest system data as JSON"""
         # https://microdot.readthedocs.io/en/latest/intro.html#json-responses
         return self.system_infos
 
     # @app.route('/update')
-    def update_system(self, req: Request) -> None:
+    async def update_system(self, req: Request) -> None:
         """Provide system update page"""
         res = send_file('/lib/templates/update.tpl')
         res.headers["Content-Type"] = "text/html"

--- a/myevse_webinterface/webinterface.py
+++ b/myevse_webinterface/webinterface.py
@@ -451,7 +451,7 @@ class Webinterface(object):
                 },
             })
 
-    def _save_system_config(self, data: dict) -> None:
+    async def _save_system_config(self, data: dict) -> None:
         """
         Update and save the system configuration to file
 
@@ -500,6 +500,7 @@ class Webinterface(object):
                           format(self.connection_mode))
 
         connection_mode = self.connection_mode
+        connection_result = False
 
         if connection_mode == self.SETUP_MODE:
             # device connection not yet configured
@@ -697,7 +698,7 @@ class Webinterface(object):
     async def perform_reboot_system(self, req: Request) -> None:
         """Process system reboot"""
         # perform soft reset, like CTRL+D
-        machine.soft_reset()
+        await machine.soft_reset()
 
         return None, 204, {'Content-Type': 'application/json; charset=UTF-8'}
 
@@ -721,7 +722,7 @@ class Webinterface(object):
         # empty response to avoid any redirects or errors due to none response
         return None, 204, {'Content-Type': 'application/json; charset=UTF-8'}
 
-    def _render_modbus_data(self, device_data: dict) -> str:
+    async def _render_modbus_data(self, device_data: dict) -> str:
         """
         Render HTML table of given device data
 
@@ -762,7 +763,7 @@ class Webinterface(object):
 
         return content
 
-    def _render_system_info(self, system_data: dict) -> str:
+    async def _render_system_info(self, system_data: dict) -> str:
         """
         Render HTML fieldset of given system data
 


### PR DESCRIPTION
### Changed
- Webserver functions use `async` and `await` to become asynchronous

### Removed
- `wait_for_irq` returns instantly, no longer required due to `/shutdown` enpoint introduced in Micropython ESP WiFi Manager 1.10.0